### PR TITLE
fix: Replace broken GitHub stats widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 <br />
 
 <h2>GitHub Stats</h2>
-<p><img src="https://github-readme-stats.vercel.app/api?username=echarrod&amp;show_icons=true" alt="GitHub Stats"></p>
+<p>
+  <img src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=echarrod&theme=default" alt="GitHub Profile Details">
+  <br />
+  <img src="https://github-profile-summary-cards.vercel.app/api/cards/stats?username=echarrod&theme=default" alt="GitHub Stats">
+</p>
 
 <!--START_SECTION:waka-->
 ![Lines of code](https://img.shields.io/badge/From%20Hello%20World%20I%27ve%20Written-22.45%20million%20lines%20of%20code-blue?style=flat)


### PR DESCRIPTION
## Summary
- The public `github-readme-stats.vercel.app` instance is returning **503** due to rate limiting
- Replaced with `github-profile-summary-cards` which provides similar functionality:
  - **Profile Details card** — contributions graph, public repos, years on GitHub
  - **Stats card** — total stars, commits, PRs, issues

## Test plan
- [ ] Check that both card images render on the profile page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to enhance profile visibility and presentation. The single statistics image has been replaced with a dual-image layout displaying both profile details and repository statistics separately, providing visitors with a more comprehensive overview of account information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->